### PR TITLE
Add contact, calendar event and OTP QR types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Four new commands: `vcard` (a vCard 3.0 contact), `mecard` (a MeCard
+  contact), `event` (a calendar event) and `otp` (a TOTP/HOTP provisioning
+  key). The OTP secret is a `SecretStr` and is masked in verbose output, like
+  the WiFi password.
+- Long option names spell underscores as dashes: a `first_name` field becomes
+  `--first-name`.
+- `make_mecard_data` accepts any `StrEnum` mapping, not only WiFi parameters.
+
 ## [5.0.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- Four new commands: `vcard` (a vCard 3.0 contact), `mecard` (a MeCard
-  contact), `event` (a calendar event) and `otp` (a TOTP/HOTP provisioning
-  key). The OTP secret is a `SecretStr` and is masked in verbose output, like
-  the WiFi password.
-- Long option names spell underscores as dashes: a `first_name` field becomes
-  `--first-name`.
-- `make_mecard_data` accepts any `StrEnum` mapping, not only WiFi parameters.
-
-## [5.0.0]
+## [5.0.0] - 2026-08-27
 
 ### Fixed
 
@@ -43,11 +31,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Four new commands: `vcard` (a vCard 3.0 contact), `mecard` (a MeCard
+  contact), `event` (a calendar event) and `otp` (a TOTP/HOTP provisioning
+  key). The OTP secret is a `SecretStr` and is masked in verbose output, like
+  the WiFi password.
 - Open WiFi networks are marked `T:nopass`, as the MECARD format expects.
 - `py.typed`, so type hints reach downstream users.
 - `CHANGELOG.md`, `LICENSE` and `SECURITY.md`.
 - Help text for every option, a description for every command, and a README
-  that documents all seven commands and the global options.
+  that documents all eleven commands and the global options.
+- `make_mecard_data` accepts any `StrEnum` mapping, not only WiFi parameters.
 
 ### Changed
 
@@ -58,6 +51,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Errors are raised as click exceptions instead of calling `sys.exit`.
 - Commands are discovered from `QRDataModel` subclasses, and click option types
   are inferred from field annotations, so the models no longer import click.
+- Long option names spell underscores as dashes: a `first_name` field becomes
+  `--first-name`.
 - Packaging moved to uv and PEP 621; the version is read from package metadata.
 - The command line lives in `makeqr.cli` (was `makeqr.cli_app`), and importing
   `makeqr` no longer pulls in click.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 [![Test](https://github.com/shpaker/makeqr/actions/workflows/tests.yml/badge.svg)](https://github.com/shpaker/makeqr/actions/workflows/tests.yml)
 [![License](https://img.shields.io/pypi/l/makeqr.svg)](https://github.com/shpaker/makeqr/blob/main/LICENSE)
 
-Generate QR codes for links, WiFi networks, geo points, e-mail, SMS and plain
-text — from the command line or from Python.
+Generate QR codes for links, WiFi networks, contacts, calendar events,
+one-time-password keys, geo points, e-mail, SMS and plain text — from the
+command line or from Python.
 
 ## Installation
 
@@ -38,6 +39,10 @@ uvx makeqr --help
 | `sms`    | A pre-filled SMS       | `makeqr sms -r +79876543210 -b 'on my way'`           |
 | `tel`    | A phone number         | `makeqr tel +79876543210`                             |
 | `text`   | Arbitrary text         | `makeqr text 'hello world'`                           |
+| `vcard`  | A vCard 3.0 contact    | `makeqr vcard -f John -t +79876543210 Doe`            |
+| `mecard` | A MeCard contact       | `makeqr mecard -f John -t +79876543210 Doe`           |
+| `event`  | A calendar event       | `makeqr event -s Standup -st 2026-09-01T12:00`        |
+| `otp`    | A TOTP/HOTP key        | `makeqr otp -l alice@example.com -s BASE32SECRET`     |
 
 The scheme may be omitted from a link — `makeqr link example.com` encodes
 `https://example.com`.

--- a/makeqr/__init__.py
+++ b/makeqr/__init__.py
@@ -4,12 +4,16 @@ from makeqr.makeqr import MakeQR
 from makeqr.models import (
     QRDataModel,
     QRDataModelType,
+    QREventModel,
     QRGeoModel,
     QRLinkModel,
     QRMailToModel,
+    QRMeCardModel,
+    QROtpModel,
     QRSMSModel,
     QRTelModel,
     QRTextModel,
+    QRVCardModel,
     QRWiFiModel,
 )
 
@@ -26,12 +30,16 @@ __all__ = (
     "MakeQR",
     "QRDataModel",
     "QRDataModelType",
+    "QREventModel",
     "QRGeoModel",
     "QRLinkModel",
     "QRMailToModel",
+    "QRMeCardModel",
+    "QROtpModel",
     "QRSMSModel",
     "QRTelModel",
     "QRTextModel",
+    "QRVCardModel",
     "QRWiFiModel",
     "__version__",
 )

--- a/makeqr/cli.py
+++ b/makeqr/cli.py
@@ -142,7 +142,7 @@ def _make_click_params_from_model(
 
         # A short flag needs an alias to derive its name from; long-only is
         # better than the "-None" a missing alias used to produce.
-        names = [f"--{name}"]
+        names = [f"--{name.replace('_', '-')}"]
         if model_field.alias:
             names.insert(0, f"-{model_field.alias}")
 

--- a/makeqr/constants.py
+++ b/makeqr/constants.py
@@ -3,6 +3,9 @@ from enum import StrEnum
 DEFAULT_LINK_SCHEME = "https"
 DEFAULT_IMAGE_FORMAT = "png"
 MECARD_SPECIAL_CHARACTERS: str = r'\;,:"'
+# vCard/vEvent TEXT values escape fewer characters than MECARD: no ':' or '"'.
+# The backslash must stay first so already-added escapes are not escaped again.
+VCARD_SPECIAL_CHARACTERS: str = r"\;,"
 
 
 class AuthType(StrEnum):
@@ -24,9 +27,31 @@ class WifiMecardParam(StrEnum):
     PASSWORD = "P"
 
 
+class MeCardParam(StrEnum):
+    NAME = "N"
+    TEL = "TEL"
+    EMAIL = "EMAIL"
+    URL = "URL"
+    NOTE = "NOTE"
+
+
+class OtpType(StrEnum):
+    TOTP = "totp"
+    HOTP = "hotp"
+
+
+class OtpAlgorithm(StrEnum):
+    # The otpauth URI expects the algorithm name in upper case verbatim.
+    SHA1 = "SHA1"
+    SHA256 = "SHA256"
+    SHA512 = "SHA512"
+
+
 class DataScheme(StrEnum):
     WIFI = "WIFI"
+    MECARD = "MECARD"
     MAILTO = "mailto"
+    OTPAUTH = "otpauth"
     TEL = "tel"
     SMS = "sms"
     GEO = "geo"

--- a/makeqr/models.py
+++ b/makeqr/models.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from datetime import UTC, datetime
+from enum import StrEnum
 from typing import TypeVar
 from urllib.parse import quote
 
@@ -16,8 +18,12 @@ from pydantic import (
 from makeqr.constants import (
     DEFAULT_LINK_SCHEME,
     MECARD_SPECIAL_CHARACTERS,
+    VCARD_SPECIAL_CHARACTERS,
     AuthType,
     DataScheme,
+    MeCardParam,
+    OtpAlgorithm,
+    OtpType,
     WifiMecardParam,
 )
 from makeqr.utils import make_link_data, make_mecard_data
@@ -48,6 +54,62 @@ QRDataModelType = TypeVar(
     "QRDataModelType",
     bound=QRDataModel,
 )
+
+
+class QREventModel(
+    QRDataModel,
+):
+    summary: str = Field(
+        alias="s",
+        description="Event title",
+    )
+    start: datetime = Field(
+        alias="st",
+        description="Start, ISO 8601, e.g. 2026-09-01T12:00",
+    )
+    end: datetime | None = Field(
+        None,
+        alias="et",
+        description="End, ISO 8601",
+    )
+    location: str | None = Field(
+        None,
+        alias="l",
+        description="Venue or address",
+    )
+    description: str | None = Field(
+        None,
+        alias="d",
+        description="Event details",
+    )
+
+    @model_validator(mode="after")
+    def check_end_after_start(self) -> "QREventModel":
+        if self.end is None:
+            return self
+        if (self.start.tzinfo is None) != (self.end.tzinfo is None):
+            msg = "start and end must both be naive or both timezone-aware"
+            raise ValueError(msg)
+        if self.end <= self.start:
+            msg = "end must be after start"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def qr_data(self) -> str:
+        lines = [
+            "BEGIN:VEVENT",
+            f"SUMMARY:{_escape_vcard(self.summary)}",
+            f"DTSTART:{_format_vevent_datetime(self.start)}",
+        ]
+        if self.end is not None:
+            lines.append(f"DTEND:{_format_vevent_datetime(self.end)}")
+        if self.location:
+            lines.append(f"LOCATION:{_escape_vcard(self.location)}")
+        if self.description:
+            lines.append(f"DESCRIPTION:{_escape_vcard(self.description)}")
+        lines.append("END:VEVENT")
+        return "\r\n".join(lines)
 
 
 class QRGeoModel(
@@ -139,6 +201,134 @@ class QRMailToModel(
         return data if not args else f"{data}?{'&'.join(args)}"
 
 
+class QRMeCardModel(
+    QRDataModel,
+):
+    last_name: str = Field(
+        alias="l",
+        description="Last name",
+    )
+    first_name: str | None = Field(
+        None,
+        alias="f",
+        description="First name",
+    )
+    tel: str | None = Field(
+        None,
+        alias="t",
+        description="Telephone number",
+    )
+    email: EmailStr | None = Field(
+        None,
+        alias="e",
+        description="E-mail address",
+    )
+    url: str | None = Field(
+        None,
+        alias="u",
+        description="Website",
+    )
+    note: str | None = Field(
+        None,
+        alias="n",
+        description="Free-form note",
+    )
+
+    @property
+    def qr_data(self) -> str:
+        name = _escape_mecard(self.last_name)
+        if self.first_name:
+            name = f"{name},{_escape_mecard(self.first_name)}"
+        fields: dict[StrEnum, str] = {
+            MeCardParam.NAME: name,
+        }
+        if self.tel:
+            fields[MeCardParam.TEL] = _escape_mecard(self.tel)
+        if self.email:
+            fields[MeCardParam.EMAIL] = _escape_mecard(self.email)
+        if self.url:
+            fields[MeCardParam.URL] = _escape_mecard(self.url)
+        if self.note:
+            fields[MeCardParam.NOTE] = _escape_mecard(self.note)
+        return make_mecard_data(
+            title=DataScheme.MECARD.value,
+            fields=fields,
+        )
+
+
+class QROtpModel(
+    QRDataModel,
+):
+    type: OtpType = Field(
+        OtpType.TOTP,
+        alias="t",
+        description="One-time password type",
+    )
+    label: str = Field(
+        alias="l",
+        description="Account the key belongs to, e.g. alice@example.com",
+    )
+    secret: SecretStr = Field(
+        alias="s",
+        description="Base32-encoded shared secret",
+    )
+    issuer: str | None = Field(
+        None,
+        alias="i",
+        description="Provider or service name",
+    )
+    algorithm: OtpAlgorithm | None = Field(
+        None,
+        alias="a",
+        description="HMAC hash algorithm",
+    )
+    digits: int | None = Field(
+        None,
+        alias="d",
+        description="Number of digits in a code",
+    )
+    period: int | None = Field(
+        None,
+        alias="p",
+        description="Code lifetime in seconds, totp only",
+    )
+    counter: int | None = Field(
+        None,
+        alias="c",
+        description="Initial counter value, hotp only",
+    )
+
+    @model_validator(mode="after")
+    def check_type_specific_params(self) -> "QROtpModel":
+        if self.type is OtpType.HOTP and self.counter is None:
+            msg = "counter is required when type is hotp"
+            raise ValueError(msg)
+        if self.type is OtpType.TOTP and self.counter is not None:
+            msg = "counter is only valid when type is hotp"
+            raise ValueError(msg)
+        if self.type is OtpType.HOTP and self.period is not None:
+            msg = "period is only valid when type is totp"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def qr_data(self) -> str:
+        label = self.label if self.issuer is None else f"{self.issuer}:{self.label}"
+        args = [f"secret={quote(self.secret.get_secret_value())}"]
+        if self.issuer is not None:
+            args.append(f"issuer={quote(self.issuer)}")
+        if self.algorithm is not None:
+            args.append(f"algorithm={self.algorithm.value}")
+        # Numeric parameters are compared to None: 0 is a valid HOTP counter.
+        if self.digits is not None:
+            args.append(f"digits={self.digits}")
+        if self.period is not None:
+            args.append(f"period={self.period}")
+        if self.counter is not None:
+            args.append(f"counter={self.counter}")
+        return f"{DataScheme.OTPAUTH.value}://{self.type.value}/{quote(label, safe='')}?{'&'.join(args)}"
+
+
 class QRSMSModel(
     QRDataModel,
 ):
@@ -191,6 +381,68 @@ class QRTextModel(
         return self.text
 
 
+class QRVCardModel(
+    QRDataModel,
+):
+    last_name: str = Field(
+        alias="l",
+        description="Last name",
+    )
+    first_name: str | None = Field(
+        None,
+        alias="f",
+        description="First name",
+    )
+    phones: tuple[str, ...] = Field(
+        (),
+        alias="t",
+        description="Telephone number, repeat for several numbers",
+    )
+    email: EmailStr | None = Field(
+        None,
+        alias="e",
+        description="E-mail address",
+    )
+    org: str | None = Field(
+        None,
+        alias="o",
+        description="Organization",
+    )
+    title: str | None = Field(
+        None,
+        alias="ti",
+        description="Job title",
+    )
+    url: str | None = Field(
+        None,
+        alias="u",
+        description="Website",
+    )
+
+    @property
+    def qr_data(self) -> str:
+        last = _escape_vcard(self.last_name)
+        first = _escape_vcard(self.first_name) if self.first_name else ""
+        full_name = f"{first} {last}".strip()
+        lines = [
+            "BEGIN:VCARD",
+            "VERSION:3.0",
+            f"N:{last};{first}",
+            f"FN:{full_name}",
+        ]
+        lines.extend(f"TEL:{phone}" for phone in self.phones)
+        if self.email:
+            lines.append(f"EMAIL:{self.email}")
+        if self.org:
+            lines.append(f"ORG:{_escape_vcard(self.org)}")
+        if self.title:
+            lines.append(f"TITLE:{_escape_vcard(self.title)}")
+        if self.url:
+            lines.append(f"URL:{self.url}")
+        lines.append("END:VCARD")
+        return "\r\n".join(lines)
+
+
 class QRWiFiModel(
     QRDataModel,
 ):
@@ -223,7 +475,7 @@ class QRWiFiModel(
 
     @property
     def qr_data(self) -> str:
-        fields = {
+        fields: dict[StrEnum, str] = {
             WifiMecardParam.SSID: _escape_mecard(self.ssid),
         }
         if self.hidden:
@@ -248,3 +500,20 @@ def _escape_mecard(
     for spec_char in MECARD_SPECIAL_CHARACTERS:
         value = value.replace(spec_char, f"\\{spec_char}")
     return value
+
+
+def _escape_vcard(
+    value: str,
+) -> str:
+    for spec_char in VCARD_SPECIAL_CHARACTERS:
+        value = value.replace(spec_char, f"\\{spec_char}")
+    return value.replace("\r\n", "\\n").replace("\r", "\\n").replace("\n", "\\n")
+
+
+def _format_vevent_datetime(
+    value: datetime,
+) -> str:
+    # Naive datetimes encode as floating local time; aware ones as UTC.
+    if value.tzinfo is None:
+        return value.strftime("%Y%m%dT%H%M%S")
+    return value.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")

--- a/makeqr/utils.py
+++ b/makeqr/utils.py
@@ -1,12 +1,14 @@
+from collections.abc import Mapping
+from enum import StrEnum
 from typing import Any
 from urllib.parse import quote
 
-from makeqr.constants import DataScheme, WifiMecardParam
+from makeqr.constants import DataScheme
 
 
 def make_mecard_data(
     title: str,
-    fields: dict[WifiMecardParam, str],
+    fields: Mapping[StrEnum, str],
 ) -> str:
     fields_list = [f"{field.value}:{value}" for field, value in fields.items()]
     return f"{title}:{';'.join(fields_list)};;"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11"
 authors = [
   { name = "Aleksandr Shpak", email = "shpaker@gmail.com" },
 ]
-keywords = ["qr", "qrcode", "cli", "wifi", "vcard", "mecard"]
+keywords = ["qr", "qrcode", "cli", "wifi", "vcard", "mecard", "event", "otp"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",

--- a/tests/qr_data/test_event.py
+++ b/tests/qr_data/test_event.py
@@ -1,0 +1,62 @@
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from makeqr.models import QREventModel
+
+
+def test_naive_event() -> None:
+    data = QREventModel(
+        summary="Standup",
+        start=datetime(2026, 9, 1, 12, 0),
+        end=datetime(2026, 9, 1, 12, 15),
+    )
+    assert data.qr_data == (
+        "BEGIN:VEVENT\r\nSUMMARY:Standup\r\nDTSTART:20260901T120000\r\nDTEND:20260901T121500\r\nEND:VEVENT"
+    )
+
+
+def test_aware_event_is_converted_to_utc() -> None:
+    tz = timezone(timedelta(hours=3))
+    data = QREventModel(summary="Standup", start=datetime(2026, 9, 1, 15, 0, tzinfo=tz))
+    assert "DTSTART:20260901T120000Z" in data.qr_data
+
+
+def test_start_accepts_iso_strings() -> None:
+    data = QREventModel(summary="x", start="2026-09-01T12:00:00")
+    assert "DTSTART:20260901T120000" in data.qr_data
+
+
+def test_optional_lines_are_omitted() -> None:
+    data = QREventModel(summary="x", start=datetime(2026, 9, 1, 12, 0))
+    assert "DTEND:" not in data.qr_data
+    assert "LOCATION:" not in data.qr_data
+    assert "DESCRIPTION:" not in data.qr_data
+
+
+def test_text_fields_are_escaped() -> None:
+    data = QREventModel(
+        summary="a,b;c",
+        start=datetime(2026, 9, 1, 12, 0),
+        location="Room 1;2",
+        description="x\ny",
+    )
+    assert r"SUMMARY:a\,b\;c" in data.qr_data
+    assert r"LOCATION:Room 1\;2" in data.qr_data
+    assert r"DESCRIPTION:x\ny" in data.qr_data
+
+
+def test_end_before_start_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="end must be after"):
+        QREventModel(summary="x", start=datetime(2026, 9, 1, 12, 0), end=datetime(2026, 9, 1, 11, 0))
+
+
+def test_end_equal_to_start_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="end must be after"):
+        QREventModel(summary="x", start=datetime(2026, 9, 1, 12, 0), end=datetime(2026, 9, 1, 12, 0))
+
+
+def test_mixed_naive_and_aware_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="both"):
+        QREventModel(summary="x", start=datetime(2026, 9, 1, 12, 0), end=datetime(2026, 9, 1, 13, 0, tzinfo=UTC))

--- a/tests/qr_data/test_mecard.py
+++ b/tests/qr_data/test_mecard.py
@@ -1,0 +1,42 @@
+import pytest
+from pydantic import ValidationError
+
+from makeqr.models import QRMeCardModel
+
+
+def test_minimal_mecard() -> None:
+    assert QRMeCardModel(last_name="Doe").qr_data == "MECARD:N:Doe;;"
+
+
+def test_mecard_with_first_name() -> None:
+    data = QRMeCardModel(last_name="Doe", first_name="John")
+    assert data.qr_data == "MECARD:N:Doe,John;;"
+
+
+def test_full_mecard() -> None:
+    data = QRMeCardModel(
+        last_name="Doe",
+        first_name="John",
+        tel="+79876543210",
+        email="john@doe.com",
+        url="https://doe.com",
+        note="Friend",
+    )
+    assert data.qr_data == r"MECARD:N:Doe,John;TEL:+79876543210;EMAIL:john@doe.com;URL:https\://doe.com;NOTE:Friend;;"
+
+
+def test_name_parts_are_escaped() -> None:
+    data = QRMeCardModel(last_name="Do;e", first_name="Jo,hn")
+    assert data.qr_data == r"MECARD:N:Do\;e,Jo\,hn;;"
+
+
+def test_invalid_email_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        QRMeCardModel(last_name="Doe", email="nope")
+
+
+def test_qr_data_is_idempotent_and_leaves_the_model_alone() -> None:
+    data = QRMeCardModel(last_name="Do;e")
+    first = data.qr_data
+    assert data.qr_data == first
+    assert data.last_name == "Do;e"

--- a/tests/qr_data/test_otp.py
+++ b/tests/qr_data/test_otp.py
@@ -1,0 +1,55 @@
+import pytest
+from pydantic import ValidationError
+
+from makeqr.constants import OtpAlgorithm, OtpType
+from makeqr.models import QROtpModel
+
+
+def test_totp_defaults() -> None:
+    data = QROtpModel(label="alice@example.com", secret="JBSWY3DPEHPK3PXP")
+    assert data.qr_data == "otpauth://totp/alice%40example.com?secret=JBSWY3DPEHPK3PXP"
+
+
+def test_totp_with_issuer() -> None:
+    data = QROtpModel(label="alice@example.com", secret="JBSWY3DPEHPK3PXP", issuer="Example")
+    assert data.qr_data == "otpauth://totp/Example%3Aalice%40example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+
+
+def test_totp_with_every_parameter() -> None:
+    data = QROtpModel(
+        label="alice@example.com",
+        secret="JBSWY3DPEHPK3PXP",
+        issuer="Example",
+        algorithm=OtpAlgorithm.SHA256,
+        digits=8,
+        period=60,
+    )
+    assert data.qr_data == (
+        "otpauth://totp/Example%3Aalice%40example.com"
+        "?secret=JBSWY3DPEHPK3PXP&issuer=Example&algorithm=SHA256&digits=8&period=60"
+    )
+
+
+def test_hotp_with_zero_counter() -> None:
+    data = QROtpModel(type=OtpType.HOTP, label="alice@example.com", secret="JBSWY3DPEHPK3PXP", counter=0)
+    assert data.qr_data == "otpauth://hotp/alice%40example.com?secret=JBSWY3DPEHPK3PXP&counter=0"
+
+
+def test_hotp_requires_counter() -> None:
+    with pytest.raises(ValidationError, match="counter is required"):
+        QROtpModel(type=OtpType.HOTP, label="a", secret="S")
+
+
+def test_totp_rejects_counter() -> None:
+    with pytest.raises(ValidationError, match="only valid when type is hotp"):
+        QROtpModel(label="a", secret="S", counter=1)
+
+
+def test_hotp_rejects_period() -> None:
+    with pytest.raises(ValidationError, match="only valid when type is totp"):
+        QROtpModel(type=OtpType.HOTP, label="a", secret="S", counter=1, period=30)
+
+
+def test_secret_is_masked_in_dumps() -> None:
+    data = QROtpModel(label="alice@example.com", secret="JBSWY3DPEHPK3PXP")
+    assert "JBSWY3DPEHPK3PXP" not in data.model_dump_json()

--- a/tests/qr_data/test_vcard.py
+++ b/tests/qr_data/test_vcard.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+
+from makeqr.models import QRVCardModel
+
+
+def test_minimal_vcard() -> None:
+    data = QRVCardModel(last_name="Doe")
+    assert data.qr_data == "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;\r\nFN:Doe\r\nEND:VCARD"
+
+
+def test_full_vcard() -> None:
+    data = QRVCardModel(
+        last_name="Doe",
+        first_name="John",
+        phones=("+79876543210", "+79876543211"),
+        email="john@doe.com",
+        org="ACME",
+        title="Engineer",
+        url="https://doe.com",
+    )
+    assert data.qr_data == (
+        "BEGIN:VCARD\r\n"
+        "VERSION:3.0\r\n"
+        "N:Doe;John\r\n"
+        "FN:John Doe\r\n"
+        "TEL:+79876543210\r\n"
+        "TEL:+79876543211\r\n"
+        "EMAIL:john@doe.com\r\n"
+        "ORG:ACME\r\n"
+        "TITLE:Engineer\r\n"
+        "URL:https://doe.com\r\n"
+        "END:VCARD"
+    )
+
+
+def test_special_characters_are_escaped() -> None:
+    data = QRVCardModel(last_name="Doe;Jr", org=r"A,B\C")
+    assert r"N:Doe\;Jr;" in data.qr_data
+    assert r"ORG:A\,B\\C" in data.qr_data
+
+
+def test_newlines_become_literal_n() -> None:
+    data = QRVCardModel(last_name="Doe", title="Line1\nLine2")
+    assert r"TITLE:Line1\nLine2" in data.qr_data
+
+
+def test_invalid_email_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        QRVCardModel(last_name="Doe", email="nope")
+
+
+def test_qr_data_is_idempotent_and_leaves_the_model_alone() -> None:
+    data = QRVCardModel(last_name="Doe;Jr", first_name="John")
+    first = data.qr_data
+    assert data.qr_data == first
+    assert data.last_name == "Doe;Jr"
+    assert data.first_name == "John"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,8 +23,15 @@ def test_version() -> None:
 def test_help_lists_every_command() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0, result.output
-    for command in ("geo", "link", "mailto", "sms", "tel", "text", "wifi"):
+    commands = ("event", "geo", "link", "mailto", "mecard", "otp", "sms", "tel", "text", "vcard", "wifi")
+    for command in commands:
         assert command in result.stdout
+
+
+def test_event() -> None:
+    result = runner.invoke(app, ["-qv", "event", "-s", "Standup", "-st", "2026-09-01T12:00:00"])
+    assert result.exit_code == 0, result.output
+    assert "DTSTART:20260901T120000" in result.stdout
 
 
 def test_geo() -> None:
@@ -67,6 +74,24 @@ def test_mailto_help_has_no_none_flag() -> None:
     assert "-None" not in result.stdout
 
 
+def test_mecard() -> None:
+    result = runner.invoke(app, ["-qv", "mecard", "-f", "John", "Doe"])
+    assert result.exit_code == 0, result.output
+    assert "MECARD:N:Doe,John;;" in result.stdout
+
+
+def test_otp() -> None:
+    result = runner.invoke(app, ["-qv", "otp", "-l", "alice@example.com", "-s", "JBSWY3DPEHPK3PXP", "-i", "Example"])
+    assert result.exit_code == 0, result.output
+    assert "otpauth://totp/Example%3Aalice%40example.com" in result.stdout
+
+
+def test_otp_secret_is_never_printed() -> None:
+    result = runner.invoke(app, ["-qv", "otp", "-l", "alice@example.com", "-s", "JBSWY3DPEHPK3PXP"])
+    assert result.exit_code == 0, result.output
+    assert "JBSWY3DPEHPK3PXP" not in result.stdout
+
+
 def test_sms() -> None:
     result = runner.invoke(app, ["-qv", "sms", "-r", "test"])
     assert result.exit_code == 0, result.output
@@ -83,6 +108,20 @@ def test_text() -> None:
     result = runner.invoke(app, ["-qv", "text", "hello"])
     assert result.exit_code == 0, result.output
     assert "Encoded: hello" in result.stdout
+
+
+def test_vcard() -> None:
+    result = runner.invoke(app, ["-qv", "vcard", "-f", "John", "-t", "+111", "-t", "+222", "Doe"])
+    assert result.exit_code == 0, result.output
+    assert "N:Doe;John" in result.stdout
+    assert "TEL:+222" in result.stdout
+
+
+def test_vcard_option_names_use_dashes() -> None:
+    result = runner.invoke(app, ["vcard", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "--first-name" in result.stdout
+    assert "--first_name" not in result.stdout
 
 
 def test_wifi() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
-from makeqr.constants import DataScheme, WifiMecardParam
+from enum import StrEnum
+
+from makeqr.constants import DataScheme, MeCardParam, WifiMecardParam
 from makeqr.utils import make_link_data, make_mecard_data
 
 
@@ -25,5 +27,10 @@ def test_make_link_data_uses_ampersand_when_query_present() -> None:
 
 
 def test_make_mecard_data() -> None:
-    fields = {WifiMecardParam.SSID: "net", WifiMecardParam.PASSWORD: "pw"}
+    fields: dict[StrEnum, str] = {WifiMecardParam.SSID: "net", WifiMecardParam.PASSWORD: "pw"}
     assert make_mecard_data(title="WIFI", fields=fields) == "WIFI:S:net;P:pw;;"
+
+
+def test_make_mecard_data_accepts_mecard_params() -> None:
+    fields: dict[StrEnum, str] = {MeCardParam.NAME: "Doe,John", MeCardParam.TEL: "+123"}
+    assert make_mecard_data(title="MECARD", fields=fields) == "MECARD:N:Doe,John;TEL:+123;;"


### PR DESCRIPTION
Adds the four most commonly requested formats that were missing: contacts, a calendar event and a 2FA key. Link wrappers (WhatsApp, Telegram) were deliberately left out — they are ordinary links.

Commands are still discovered from `QRDataModel` subclasses, so each type is a model plus its tests.

## New commands

| Command | Encodes | Example |
|---|---|---|
| `vcard` | A vCard 3.0 contact | `makeqr vcard -f John -t +79876543210 Doe` |
| `mecard` | A MeCard contact | `makeqr mecard -f John -t +79876543210 Doe` |
| `event` | A calendar event (vEvent) | `makeqr event -s Standup -st 2026-09-01T12:00` |
| `otp` | A TOTP/HOTP key | `makeqr otp -l alice@example.com -s BASE32SECRET -i Example` |

## Notes

- **vCard escaping is not MeCard escaping.** RFC 2426 escapes `\`, `;`, `,` and newlines, but not `:` or `"`, so `vcard`/`event` use their own `_escape_vcard` rather than reusing `_escape_mecard`.
- **`make_mecard_data` accepts any `StrEnum` mapping** now, instead of only `WifiMecardParam`, so `mecard` reuses it as is.
- **Event datetimes:** naive values encode as floating local time (`20260901T120000`), aware ones are converted to UTC (`...Z`). The validator rejects an end at or before the start, and rejects mixing naive with aware — comparing those would otherwise raise a bare `TypeError` that pydantic would not turn into a `ValidationError`.
- **The OTP secret is a `SecretStr`**, so the existing redaction masks it in verbose output exactly like the WiFi password. `hotp` requires `counter`; `totp` forbids it. Numeric parameters are compared to `None`, because `counter=0` is valid.
- **Long options now spell underscores as dashes** (`--first-name`), a one-line change in `_make_click_params_from_model`. No existing field contains an underscore, so the seven current commands are unaffected.

## Verification

`just lint` (ruff, formatting, ty) passes. `just test`: 105 passed, coverage 97.65% with `models.py` at 100%. All four commands were also run end to end, including the check that the OTP secret never reaches stdout.