### PR TITLE
Publish to PyPI with an API token instead of trusted publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,10 +11,6 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      contents: read
-      id-token: write  # mint the OIDC token for trusted publishing
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v10.0.1
@@ -29,4 +25,6 @@ jobs:
             exit 1
           fi
       - run: uv build
-      - run: uv publish --trusted-publishing always
+      - run: uv publish --check-url https://pypi.org/simple/
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PASS }}


### PR DESCRIPTION
The 5.0.0 release [run](https://github.com/shpaker/makeqr/actions/runs/33113142951) failed at the upload step, not the build. `uv publish --trusted-publishing always` minted a valid OIDC token, but PyPI answered `422 invalid-publisher` — "valid token, but no corresponding publisher" — because no trusted publisher is registered for the `makeqr` project against these claims (`repo:shpaker/makeqr`, workflow `pypi.yml`, environment `pypi`).

Switch to the same approach that works in `epyxid`: publish with the API token the repo already holds in `PYPI_PASS`. That drops the need for `id-token: write` and the `pypi` environment. `--check-url` is the uv equivalent of `--skip-existing`, so a re-run after a partial upload does not fail.